### PR TITLE
Add CodeQL analysis to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,35 @@ jobs:
       - name: Run tests
         run: echo 'tests'
 
+  analyse:
+    name: analyse
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          queries: +security-extended
+        # Override language selection by uncommenting this and choosing your languages
+        # with:
+        #   languages: go, javascript, csharp, python, cpp, java
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
   deploy:
     name: deploy
     needs: [ tests ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
A new 'analyse' job has been added to the CI workflow. This job, which runs on Ubuntu-latest, is responsible for checking out the repository, initializing CodeQL with 'security-extended' queries, auto-building, and performing CodeQL analysis. The goal is to improve the security of the codebase by identifying potential vulnerabilities.