### PR TITLE
Update Node version and enhance Docker image security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:20.13-alpine3.20
+FROM node:22.13-alpine3.21
 
-RUN adduser -D -g AppUser -h /app -s /sbin/nologin appuser
+RUN adduser -D -g AppUser -h /app -s /sbin/nologin appuser && apk upgrade -U --no-cache
 
 WORKDIR /app
 


### PR DESCRIPTION
Upgrade the base image to Node 22.13 on Alpine 3.21 for improved runtime support. Added `apk upgrade` to install the latest security updates and ensure a more secure environment.